### PR TITLE
add --output-dir option

### DIFF
--- a/src/linker/cli.py
+++ b/src/linker/cli.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Tuple
+from typing import Optional, Tuple
 
 import click
 from loguru import logger
@@ -32,6 +32,15 @@ def linker():
     type=click.Path(exists=True, dir_okay=False, resolve_path=True),
 )
 @click.option(
+    "--output-dir",
+    type=click.Path(exists=False, dir_okay=True, resolve_path=True),
+    help=(
+        "The directory to write results and incidental files (logs, etc.) to. "
+        "If no value is passed, results will be written to a 'results/' directory "
+        "in the current working directory."
+    ),
+)
+@click.option(
     "--computing-environment",
     default="local",
     show_default=True,
@@ -52,6 +61,7 @@ def linker():
 def run(
     pipeline_specification: str,
     input_data: str,
+    output_dir: Optional[str],
     computing_environment: str,
     verbose: int,
     with_debugger: bool,
@@ -71,7 +81,7 @@ def run(
         input_data=input_data,
     )
     # TODO [MIC-4493]: Add configuration validation
-    results_dir = prepare_results_directory(config)
+    results_dir = prepare_results_directory(output_dir, config)
     logger.info(f"Results directory: {str(results_dir)}")
     main = handle_exceptions(
         func=runner.main, exceptions_logger=logger, with_debugger=with_debugger

--- a/src/linker/utilities/cli_utils.py
+++ b/src/linker/utilities/cli_utils.py
@@ -5,7 +5,7 @@ import sys
 from bdb import BdbQuit
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, TextIO
+from typing import Any, Callable, Optional, TextIO
 
 from loguru import logger
 
@@ -89,10 +89,9 @@ def _add_logging_sink(
         )
 
 
-def prepare_results_directory(config: Config) -> Path:
-    results_dir = _generate_results_dir_name()
+def prepare_results_directory(output_dir: Optional[str], config: Config) -> Path:
+    results_dir = _generate_results_dir_name(output_dir)
     _ = os.umask(0o002)
-    # TODO: Consider adding an output directory argument
     results_dir.mkdir(parents=True, exist_ok=False)
     shutil.copy(config.pipeline_path, results_dir)
     if config.computing_environment != "local":
@@ -101,7 +100,11 @@ def prepare_results_directory(config: Config) -> Path:
     return results_dir
 
 
-def _generate_results_dir_name():
+def _generate_results_dir_name(output_dir: Optional[str]):
     launch_time = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
-    output_root = Path("results") / launch_time
+    if output_dir:
+        output_root = Path(output_dir) / launch_time
+    else:
+        output_root = Path("results") / launch_time
+
     return output_root.resolve()


### PR DESCRIPTION
## Add `--output-dir` option
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc --> implementation
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4458
- *Research reference*: <!--Link to research documentation for code --> [milestone 1.0.4](https://uwnetid.sharepoint.com/:w:/r/sites/ihme_simulation_science_team/_layouts/15/doc2.aspx?sourcedoc=%7B9805A749-67D7-497B-9EA8-AD8D8C879559%7D&file=Milestones.docx&action=default&mobileredirect=true)

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
One of two or three PRs for this ticket.

This adds a new `--output-dir` option. If not passed, it creates a 
"results/" directory at the working directory. This still
creates a time-stamped sub-directory at the output director - 
that option will be implemented in a follow-up PR.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
manually tested
