### PR TITLE
Feature/sbachmei/mic 4458 timestamp option

### DIFF
--- a/src/linker/cli.py
+++ b/src/linker/cli.py
@@ -90,7 +90,6 @@ def run(
     # TODO [MIC-4493]: Add configuration validation
     results_dir = prepare_results_directory(output_dir, timestamp, config)
     logger.info(f"Results directory: {str(results_dir)}")
-    breakpoint()
     main = handle_exceptions(
         func=runner.main, exceptions_logger=logger, with_debugger=with_debugger
     )

--- a/src/linker/cli.py
+++ b/src/linker/cli.py
@@ -41,6 +41,12 @@ def linker():
     ),
 )
 @click.option(
+    "--timestamp/--no-timestamp",
+    default=True,
+    show_default=True,
+    help="Save the results in a timestamped sub-directory of --output-dir",
+)
+@click.option(
     "--computing-environment",
     default="local",
     show_default=True,
@@ -62,6 +68,7 @@ def run(
     pipeline_specification: str,
     input_data: str,
     output_dir: Optional[str],
+    timestamp: bool,
     computing_environment: str,
     verbose: int,
     with_debugger: bool,
@@ -81,8 +88,9 @@ def run(
         input_data=input_data,
     )
     # TODO [MIC-4493]: Add configuration validation
-    results_dir = prepare_results_directory(output_dir, config)
+    results_dir = prepare_results_directory(output_dir, timestamp, config)
     logger.info(f"Results directory: {str(results_dir)}")
+    breakpoint()
     main = handle_exceptions(
         func=runner.main, exceptions_logger=logger, with_debugger=with_debugger
     )

--- a/src/linker/cli.py
+++ b/src/linker/cli.py
@@ -44,7 +44,7 @@ def linker():
     "--timestamp/--no-timestamp",
     default=True,
     show_default=True,
-    help="Save the results in a timestamped sub-directory of --output-dir",
+    help="Save the results in a timestamped sub-directory of --output-dir.",
 )
 @click.option(
     "--computing-environment",

--- a/src/linker/utilities/cli_utils.py
+++ b/src/linker/utilities/cli_utils.py
@@ -105,9 +105,8 @@ def prepare_results_directory(
 
 def _generate_results_dir_name(output_dir: Optional[str], timestamp: bool):
     launch_time = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
-    if output_dir:
-        output_root = Path(output_dir) / launch_time if timestamp else Path(output_dir)
-    else:
-        output_root = Path("results") / launch_time if timestamp else Path("results")
+    output_root = Path("results" if output_dir is None else output_dir).resolve()
+    if timestamp:
+        output_root = output_root / launch_time
 
-    return output_root.resolve()
+    return output_root

--- a/src/linker/utilities/cli_utils.py
+++ b/src/linker/utilities/cli_utils.py
@@ -89,10 +89,12 @@ def _add_logging_sink(
         )
 
 
-def prepare_results_directory(output_dir: Optional[str], config: Config) -> Path:
-    results_dir = _generate_results_dir_name(output_dir)
+def prepare_results_directory(
+    output_dir: Optional[str], timestamp: bool, config: Config
+) -> Path:
+    results_dir = _generate_results_dir_name(output_dir, timestamp)
     _ = os.umask(0o002)
-    results_dir.mkdir(parents=True, exist_ok=False)
+    results_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy(config.pipeline_path, results_dir)
     if config.computing_environment != "local":
         shutil.copy(config.computing_environment_path, results_dir)
@@ -100,11 +102,11 @@ def prepare_results_directory(output_dir: Optional[str], config: Config) -> Path
     return results_dir
 
 
-def _generate_results_dir_name(output_dir: Optional[str]):
+def _generate_results_dir_name(output_dir: Optional[str], timestamp: bool):
     launch_time = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
     if output_dir:
-        output_root = Path(output_dir) / launch_time
+        output_root = Path(output_dir) / launch_time if timestamp else Path(output_dir)
     else:
-        output_root = Path("results") / launch_time
+        output_root = Path("results") / launch_time if timestamp else Path("results")
 
     return output_root.resolve()

--- a/src/linker/utilities/cli_utils.py
+++ b/src/linker/utilities/cli_utils.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Optional, TextIO
 
+import click
 from loguru import logger
 
 from linker.configuration import Config

--- a/src/linker/utilities/singularity_utils.py
+++ b/src/linker/utilities/singularity_utils.py
@@ -13,16 +13,13 @@ def run_with_singularity(input_data: List[Path], results_dir: Path, step_dir: Pa
 
 
 def _build_container(results_dir: Path, step_dir: Path) -> None:
-    if (results_dir / "image.sif").exists():
-        raise RuntimeError(
-            "Trying to build a Singularity image.sif but one already exists at "
-            f"{results_dir}"
-        )
     cmd = (
-        f"singularity build {results_dir}/image.sif "
+        f"singularity build --force {results_dir}/image.sif "
         f"docker-archive://{step_dir}/image.tar.gz"
     )
     logger.info("Building the singularity container from docker image")
+    if (results_dir / "image.sif").exists():
+        logger.warning(f"Overwriting an existing singularity image {results_dir}/image.sif")
     _run_cmd(results_dir, cmd)
 
 


### PR DESCRIPTION
## Add `--timestamp / --no-timestamp` option
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc --> implementation
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4458
- *Research reference*: [milestone 1.0.4](https://uwnetid.sharepoint.com/:w:/r/sites/ihme_simulation_science_team/_layouts/15/doc2.aspx?sourcedoc=%7B9805A749-67D7-497B-9EA8-AD8D8C879559%7D&file=Milestones.docx&action=default&mobileredirect=true)

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> This is the second of three PRs for this task. It implements a
`--timestamp / --no-timestamp` switch that defaults to timestamping
the results.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
--> manually tested

