### PR TITLE
hide run_slurm_job

### DIFF
--- a/src/linker/cli.py
+++ b/src/linker/cli.py
@@ -100,7 +100,7 @@ def run(
     logger.info("*** FINISHED ***")
 
 
-@linker.command()
+@linker.command(hidden=True)
 @click.argument(
     "container_engine",
     type=click.Choice(["docker", "singularity", "None"]),
@@ -124,8 +124,8 @@ def run_slurm_job(
     input_data: Tuple[str],
     verbose: int,
 ) -> None:
-    """(TEMPORARY COMMAND FOR DEVELOPMENT) Runs a job on Slurm. The standard use case is this would be kicked off
-    when a slurm computing environment is defined in the environment.yaml
+    """Runs a job on Slurm. The standard use case is this would be kicked off
+    when a slurm computing environment is defined in the environment.yaml.
     """
     configure_logging_to_terminal(verbose)
     results_dir = Path(results_dir)


### PR DESCRIPTION
## Hide `run-slurm-job` command
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc --> other
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4458
- *Research reference*: <!--Link to research documentation for code --> na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> The initial goal was to refactor so that we no longer needed a second
linker command `run-slurm-job` now that we definitively know the
results directory due to the previous PR. However, I forgot that we
also need to know the pipeline step name we are running for each
cluster job and so can't so easily remove this command.

So instead we're just hiding it.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
tested
