### PR TITLE
Treat docker and singularity equally

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owners
-* @aflaxman @albrja @hussain-jafari @mattkappel @patricktnast @rmudambi @stevebachmeier
+* @aflaxman @albrja @hussain-jafari @mattkappel @patricktnast @rmudambi @stevebachmeier @zmbc

--- a/README.md
+++ b/README.md
@@ -39,17 +39,30 @@ The docker images are built from the Dockerfile. There may be unique situations,
 however, where you want to share a pre-built image. Images can be quite large and so distributing via pypi is not an option. One common method of sharing is to use the docker repository. Another one is to save the built image as an executable .tar file which can be distributed like any other file.
 
 To create an image .tar file from a Dockerfile, first ensure Docker is installed
-then convert like the following example:
+then convert like the following example for some `<implementation>`:
 
 ```
-$ cd <path/to/repositories>/linker/steps/pvs_like_case_study_sample_data/
+$ cd <path/to/repositories>/linker/steps/<step_name>/implementations/<implementation>
 $ # build the image
-$ sudo docker build -t linker:pvs_like_case_study_sample_data .
+$ sudo docker build -t linker:<implementation> .
 $ # save as compressed tarball
-$ sudo docker save linker | gzip > image.tar.gz
+$ sudo docker save linker:<implementation> | gzip > image.tar.gz
 $ # remove the image
-$ sudo docker rmi linker:pvs_like_case_study_sample_data
+$ sudo docker rmi linker:<implementation>
 ```
 
-You should now have a step.tar image file alongside the Dockerfile which can be
-used to spin up the container.
+You should now have an image file named `image.tar.gz` alongside the Dockerfile 
+which can be used to spin up the container.
+
+
+## Creating a singularity image to be shared
+
+Singularity images should be built from a docker image created using the
+instructions in the section above. With an `image.tar.gz` docker image,
+you can create a SIF using:
+
+```
+$ cd <path/to/repositories>/linker/steps/<step_name>/implementations/<implementation>
+$ # convert the image from the docker image
+$ singularity build --force image.sif docker-archive://$(pwd)/image.tar.gz
+```

--- a/src/linker/cli.py
+++ b/src/linker/cli.py
@@ -28,10 +28,12 @@ def linker():
     type=click.Path(exists=True, dir_okay=False, resolve_path=True),
 )
 @click.argument(
+    "-i",
     "input_data",
     type=click.Path(exists=True, dir_okay=False, resolve_path=True),
 )
 @click.option(
+    "-o",
     "--output-dir",
     type=click.Path(exists=False, dir_okay=True, resolve_path=True),
     help=(
@@ -47,10 +49,12 @@ def linker():
     help="Save the results in a timestamped sub-directory of --output-dir.",
 )
 @click.option(
+    "-e",
     "--computing-environment",
     default="local",
     show_default=True,
     type=click.STRING,
+    ### XXX TODO: should we require an environment.yaml and get rid of 'local'?
     help=(
         "The computing environment on which to launch the step. Can be either "
         "'local' or a path to an environment.yaml file."

--- a/src/linker/cli.py
+++ b/src/linker/cli.py
@@ -28,7 +28,6 @@ def linker():
     type=click.Path(exists=True, dir_okay=False, resolve_path=True),
 )
 @click.argument(
-    "-i",
     "input_data",
     type=click.Path(exists=True, dir_okay=False, resolve_path=True),
 )
@@ -51,16 +50,12 @@ def linker():
 @click.option(
     "-e",
     "--computing-environment",
-    default="local",
+    default=None,
     show_default=True,
-    type=click.STRING,
-    ### XXX TODO: should we require an environment.yaml and get rid of 'local'?
-    help=(
-        "The computing environment on which to launch the step. Can be either "
-        "'local' or a path to an environment.yaml file."
-    ),
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+    help=("Path to a computing environment yaml file on which to launch the step."),
 )
-@click.option("-v", "verbose", count=True, help="Configure logging verbosity.", hidden=True)
+@click.option("-v", "--verbose", count=True, help="Increase logging verbosity.", hidden=True)
 @click.option(
     "--pdb",
     "with_debugger",

--- a/src/linker/configuration.py
+++ b/src/linker/configuration.py
@@ -75,7 +75,7 @@ class Config:
             return {"computing_environment": "local", "container_engine": "undefined"}
         filepath = Path(computing_environment).resolve()
         if not filepath.is_file():
-            raise RuntimeError(
+            raise FileNotFoundError(
                 "Computing environment is expected to be a path to an existing"
                 f" yaml file. Input was: '{computing_environment}'"
             )

--- a/src/linker/runner.py
+++ b/src/linker/runner.py
@@ -57,7 +57,7 @@ def run_container(
     elif container_engine == "singularity":
         run_with_singularity(input_data, results_dir, step_dir)
     else:
-        if container_engine:
+        if container_engine and container_engine != "undefined":
             logger.warning(
                 "The container engine is expected to be either 'docker' or "
                 f"'singularity' but got '{container_engine}' - trying to run "

--- a/src/linker/specifications/environment.yaml
+++ b/src/linker/specifications/environment.yaml
@@ -1,5 +1,5 @@
 computing_environment: slurm
-container_engine: singularity  # or docker
+# container_engine: singularity  # singularity or docker; comment out completely if unknown
 slurm:
   account: proj_simscience
   partition: all.q

--- a/src/linker/specifications/environment.yaml
+++ b/src/linker/specifications/environment.yaml
@@ -1,5 +1,5 @@
 computing_environment: slurm
-# container_engine: singularity  # singularity or docker; comment out completely if unknown
+container_engine: singularity  # or docker
 slurm:
   account: proj_simscience
   partition: all.q

--- a/src/linker/utilities/singularity_utils.py
+++ b/src/linker/utilities/singularity_utils.py
@@ -6,28 +6,16 @@ from loguru import logger
 
 
 def run_with_singularity(input_data: List[Path], results_dir: Path, step_dir: Path) -> None:
-    logger.info("Trying to run container with singularity")
-    _build_container(results_dir, step_dir)
+    logger.info("Running container with singularity")
     _run_container(input_data, results_dir, step_dir)
     _clean(results_dir, step_dir)
-
-
-def _build_container(results_dir: Path, step_dir: Path) -> None:
-    cmd = (
-        f"singularity build --force {results_dir}/image.sif "
-        f"docker-archive://{step_dir}/image.tar.gz"
-    )
-    logger.info("Building the singularity container from docker image")
-    if (results_dir / "image.sif").exists():
-        logger.warning(f"Overwriting an existing singularity image {results_dir}/image.sif")
-    _run_cmd(results_dir, cmd)
 
 
 def _run_container(input_data: List[Path], results_dir: Path, step_dir: Path) -> None:
     cmd = f"singularity run --pwd {step_dir} --bind {results_dir}:/results "
     for filepath in input_data:
         cmd += f"--bind {str(filepath)}:/input_data/{str(filepath.name)} "
-    cmd += f"{results_dir}/image.sif"
+    cmd += f"{step_dir}/image.sif"
     logger.info("Running the singularity container")
     _run_cmd(results_dir, cmd)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -17,16 +17,12 @@ from tests.unit.conftest import ENV_CONFIG_DICT, PIPELINE_CONFIG_DICT
     ],
 )
 def test_bad_computing_environment_fails(config_path, computing_environment):
-    match = (
-        "Computing environment is expected to be either 'local' or a path to an "
-        f"existing yaml file. Input is neither: '{computing_environment}'"
-    )
-    with pytest.raises(RuntimeError, match=match):
+    with pytest.raises(FileNotFoundError):
         Config(f"{config_path}/pipeline.yaml", computing_environment, "foo")
 
 
 def test_local_computing_environment(config_path):
-    config = Config(f"{config_path}/pipeline.yaml", "local", f"{config_path}/input_data.yaml")
+    config = Config(f"{config_path}/pipeline.yaml", None, f"{config_path}/input_data.yaml")
     assert config.computing_environment == "local"
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -21,7 +21,7 @@ def test_bad_computing_environment_fails(config_path, computing_environment):
         Config(f"{config_path}/pipeline.yaml", computing_environment, "foo")
 
 
-def test_local_computing_environment(config_path):
+def test_default_computing_environment(config_path):
     config = Config(f"{config_path}/pipeline.yaml", None, f"{config_path}/input_data.yaml")
     assert config.computing_environment == "local"
 


### PR DESCRIPTION
## Treat docker and singularity equally

### Description
- *Category*:  implementation
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4515

### Changes and notes
- Adds short options for output directory (-o) and computing environment (-e)
- Removes singularity container builds -- assumes implementation directory contains an `image.sif`.
- The computing environment CLI option now only accepts a path to an existing yaml and defaults to None. If None, assume computing environment is local and preserve container engine behavior, try docker first, singularity on fail.
- Updates README text to include singularity instructions, minor corrections to the docker instructions
- Updates tests for the above.

### Verification and Testing
Existing tests continue to pass. Manual testing of all permutations (local, slurm) x (undefined, docker, singularity) resulted in expected output.

