### PR TITLE
one implementation metadata file

### DIFF
--- a/src/linker/cli.py
+++ b/src/linker/cli.py
@@ -113,10 +113,9 @@ def run(
 @click.argument("step_name")
 @click.argument("implementation_name")
 @click.argument(
-    "implementation_dir",
+    "container_location",
     type=click.Path(exists=True, resolve_path=True),
 )
-@click.argument("container_full_stem")
 @click.option("--input-data", multiple=True)
 @click.option("-v", "verbose", count=True, help="Configure logging verbosity.", hidden=True)
 def run_slurm_job(
@@ -124,8 +123,7 @@ def run_slurm_job(
     results_dir: str,
     step_name: str,
     implementation_name: str,
-    implementation_dir: str,
-    container_full_stem: str,
+    container_location: str,
     input_data: Tuple[str],
     verbose: int,
 ) -> None:
@@ -142,8 +140,7 @@ def run_slurm_job(
         results_dir=Path(results_dir),
         step_name=step_name,
         implementation_name=implementation_name,
-        implementation_dir=Path(implementation_dir),
-        container_full_stem=container_full_stem,
+        container_location=Path(container_location),
     )
 
     logger.info("*** FINISHED ***")

--- a/src/linker/implementation.py
+++ b/src/linker/implementation.py
@@ -37,6 +37,10 @@ class Implementation:
         return load_yaml(metadata_path)
 
     def _get_container_location(self) -> Path:
+        if not self.name in self._metadata:
+            raise RuntimeError(
+                f"Implementation '{self.name}' is not defined in implementation_metadata.yaml"
+            )
         return Path(self._metadata[self.name]["path"])
 
     def _validate(self) -> None:

--- a/src/linker/steps/implementation_metadata.yaml
+++ b/src/linker/steps/implementation_metadata.yaml
@@ -1,0 +1,12 @@
+pvs_like_python:
+  step: pvs_like_case_study
+  path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/containers/
+pvs_like_r:
+  step: pvs_like_case_study
+  path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/containers/
+pvs_like_spark_local:
+  step: pvs_like_case_study
+  path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/containers/
+pvs_like_spark_cluster:
+  step: pvs_like_case_study
+  path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/containers/

--- a/src/linker/steps/pvs_like_case_study/implementations/pvs_like_python/.dockerignore
+++ b/src/linker/steps/pvs_like_case_study/implementations/pvs_like_python/.dockerignore
@@ -1,3 +1,0 @@
-**/Dockerfile
-**/*.tar
-**/*.tar.gz

--- a/src/linker/steps/pvs_like_case_study/implementations/pvs_like_python/metadata.yaml
+++ b/src/linker/steps/pvs_like_case_study/implementations/pvs_like_python/metadata.yaml
@@ -1,5 +1,0 @@
-step: pvs_like_case_study
-image:
-  path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/containers
-  # FIXME: how to better handle .sif vs .tar.gz?
-  filename: pvs_like_python  # .sif or .tar.gz

--- a/src/linker/steps/pvs_like_case_study/implementations/pvs_like_r/.dockerignore
+++ b/src/linker/steps/pvs_like_case_study/implementations/pvs_like_r/.dockerignore
@@ -1,3 +1,0 @@
-**/Dockerfile
-**/*.tar
-**/*.tar.gz

--- a/src/linker/steps/pvs_like_case_study/implementations/pvs_like_r/metadata.yaml
+++ b/src/linker/steps/pvs_like_case_study/implementations/pvs_like_r/metadata.yaml
@@ -1,5 +1,0 @@
-step: pvs_like_case_study
-image:
-  path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/containers
-  # FIXME: how to better handle .sif vs .tar.gz?
-  filename: pvs_like_r  # .sif or .tar.gz

--- a/src/linker/steps/pvs_like_case_study/implementations/pvs_like_spark_cluster/metadata.yaml
+++ b/src/linker/steps/pvs_like_case_study/implementations/pvs_like_spark_cluster/metadata.yaml
@@ -1,5 +1,0 @@
-step: pvs_like_case_study
-image:
-  path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/containers
-  # FIXME: how to better handle .sif vs .tar.gz?
-  filename: pvs_like_spark_cluster  # .sif or .tar.gz

--- a/src/linker/steps/pvs_like_case_study/implementations/pvs_like_spark_local/metadata.yaml
+++ b/src/linker/steps/pvs_like_case_study/implementations/pvs_like_spark_local/metadata.yaml
@@ -1,5 +1,0 @@
-step: pvs_like_case_study
-image:
-  path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/containers
-  # FIXME: how to better handle .sif vs .tar.gz?
-  filename: pvs_like_spark_local  # .sif or .tar.gz

--- a/src/linker/utilities/docker_utils.py
+++ b/src/linker/utilities/docker_utils.py
@@ -7,10 +7,10 @@ from docker.models.containers import Container
 from loguru import logger
 
 
-def run_with_docker(input_data: List[Path], results_dir: Path, container_dir: Path) -> None:
+def run_with_docker(input_data: List[Path], results_dir: Path, container_path: Path) -> None:
     logger.info("Running container with docker")
     client = get_docker_client()
-    image_id = _load_image(client, container_dir)
+    image_id = _load_image(client, container_path)
     container = _run_container(client, image_id, input_data, results_dir)
     _clean(client, image_id, container)
 

--- a/src/linker/utilities/singularity_utils.py
+++ b/src/linker/utilities/singularity_utils.py
@@ -6,9 +6,23 @@ from loguru import logger
 
 
 def run_with_singularity(
-    input_data: List[Path], results_dir: Path, implementation_dir: Path, container_path: Path
+    input_data: List[Path],
+    results_dir: Path,
+    container_path: Path,
+    step_name: str,
+    implementation_name: str,
 ) -> None:
     logger.info("Running container with singularity")
+    # TODO [MIC-4708]: break this singularity implementation_dir hard-coding
+    ## Need to figure out how to add files to singualrity container rather than
+    ## changing the pwd of the container
+    implementation_dir = (
+        Path(__file__).parent.parent
+        / "steps"
+        / step_name
+        / "implementations"
+        / implementation_name
+    )
     _run_container(input_data, results_dir, implementation_dir, container_path)
     _clean(results_dir, implementation_dir, container_path)
 
@@ -40,6 +54,6 @@ def _run_cmd(results_dir: Path, cmd: str) -> None:
         output_file.write(process.stderr)
 
 
-def _clean(results_dir: Path, step_dir: Path, container_dir: Path) -> None:
+def _clean(results_dir: Path, implementation_dir: Path, container_path: Path) -> None:
     pass
     # TODO: do I need to clean up the cache?

--- a/tests/unit/test_implementation.py
+++ b/tests/unit/test_implementation.py
@@ -11,7 +11,8 @@ def test_no_container(mocker):
         return_value=Path("some/path/with/no/container"),
     )
     with pytest.raises(
-        RuntimeError, match="Container 'some/path/with/no/container/pvs_like_python' does not exist."
+        RuntimeError,
+        match="Container 'some/path/with/no/container/pvs_like_python' does not exist.",
     ):
         Implementation(step_name="pvs_like_case_study", implementation_name="pvs_like_python")
 
@@ -34,3 +35,20 @@ def test_implemenation_does_not_match_step(mocker):
         match="Implementaton's metadata step 'step-1' does not match pipeline configuration's step 'step-2'",
     ):
         Implementation(step_name="step-2", implementation_name="some-implementation")
+
+
+def test_implementation_is_missing_from_metadata(mocker):
+    mocker.patch(
+        "linker.implementation.Implementation._load_metadata",
+        return_value={
+            "some-implementation": {
+                "step": "some-step",
+                "path": "/some/path",
+            },
+        },
+    )
+    with pytest.raises(
+        RuntimeError,
+        match="Implementation 'some-other-implementation' is not defined in implementation_metadata.yaml",
+    ):
+        Implementation(step_name="some-step", implementation_name="some-other-implementation")

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -8,6 +8,7 @@ from linker.step import Step
 def test__get_steps(config, mocker):
     mocker.patch("linker.pipeline.Pipeline._validate")
     mocker.patch("linker.implementation.Implementation._load_metadata")
+    mocker.patch("linker.implementation.Implementation._get_container_location")
     mocker.patch("linker.implementation.Implementation._validate")
     config.pipeline = {
         "steps": {
@@ -25,6 +26,7 @@ def test__get_steps(config, mocker):
 
 def test_unsupported_step(test_dir, mocker):
     mocker.patch("linker.implementation.Implementation._load_metadata")
+    mocker.patch("linker.implementation.Implementation._get_container_location")
     mocker.patch("linker.implementation.Implementation._validate")
     config = Config(
         f"{test_dir}/bad_step_pipeline.yaml",  # pipeline with unsupported step


### PR DESCRIPTION
## Streamline implementation metadata into a single file

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc --> refactor
- *JIRA issue*: na
- *Research reference*: <!--Link to research documentation for code --> na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> This PR came out of a discussion w/ Rajan about how there are currently
duplicate places where pipelines/metadata are defined. e.g., a pipeline "step"
is defined:

- in the pipeline.yaml
- in the hard-coded src/linker/steps/<step_name>/ directory structure
- in the implementation metadata.yaml "step" key

Eventually we'll likely want to remove the folder structure altogether, but for now
singularity requires it and so it's effectively part of the metadata. Given that, then,
it's completely unnecessary to specify a "step" in an implementation metadata file
since the step is the folder that implementation lives in.

This approach then simplifies the metadata required for each implementation
and also streamlines all of them into a single file. This should make it easier
for future users to add their own implementations.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

