### PR TITLE
Feature/sbachmei/mic 4754 improve logging dir

### DIFF
--- a/src/linker/cli.py
+++ b/src/linker/cli.py
@@ -113,7 +113,7 @@ def run(
     type=click.Path(exists=True, resolve_path=True),
 )
 @click.argument(
-    "diag_dir",
+    "diagnostics_dir",
     type=click.Path(exists=True, resolve_path=True),
 )
 @click.argument("step_name")
@@ -124,7 +124,7 @@ def run(
 def run_slurm_job(
     container_engine: str,
     results_dir: str,
-    diag_dir: str,
+    diagnostics_dir: str,
     step_name: str,
     implementation_name: str,
     container_full_stem: str,
@@ -142,7 +142,7 @@ def run_slurm_job(
         container_engine=container_engine,
         input_data=[Path(x) for x in input_data],
         results_dir=Path(results_dir),
-        diag_dir=Path(diag_dir),
+        diagnostics_dir=Path(diagnostics_dir),
         step_name=step_name,
         implementation_name=implementation_name,
         container_full_stem=container_full_stem,

--- a/src/linker/cli.py
+++ b/src/linker/cli.py
@@ -113,7 +113,7 @@ def run(
     type=click.Path(exists=True, resolve_path=True),
 )
 @click.argument(
-    "log_dir",
+    "diag_dir",
     type=click.Path(exists=True, resolve_path=True),
 )
 @click.argument("step_name")
@@ -124,7 +124,7 @@ def run(
 def run_slurm_job(
     container_engine: str,
     results_dir: str,
-    log_dir: str,
+    diag_dir: str,
     step_name: str,
     implementation_name: str,
     container_full_stem: str,
@@ -142,7 +142,7 @@ def run_slurm_job(
         container_engine=container_engine,
         input_data=[Path(x) for x in input_data],
         results_dir=Path(results_dir),
-        log_dir=Path(log_dir),
+        diag_dir=Path(diag_dir),
         step_name=step_name,
         implementation_name=implementation_name,
         container_full_stem=container_full_stem,

--- a/src/linker/cli.py
+++ b/src/linker/cli.py
@@ -84,7 +84,7 @@ def run(
     logger.info("Running pipeline")
     pipeline_specification = Path(pipeline_specification)
     input_data = Path(input_data)
-    results_dir, log_dir = create_results_directory(output_dir, timestamp)
+    results_dir = create_results_directory(output_dir, timestamp)
     logger.info(f"Results directory: {str(results_dir)}")
     # TODO [MIC-4493]: Add configuration validation
     config = Config(
@@ -98,7 +98,6 @@ def run(
     main(
         config=config,
         results_dir=results_dir,
-        log_dir=log_dir,
     )
     logger.info(f"Results directory: {str(results_dir)}")
     logger.info("*** FINISHED ***")

--- a/src/linker/implementation.py
+++ b/src/linker/implementation.py
@@ -23,13 +23,13 @@ class Implementation:
         container_engine: str,
         input_data: List[Path],
         results_dir: Path,
-        diag_dir: Path,
+        diagnostics_dir: Path,
     ) -> None:
         runner(
             container_engine=container_engine,
             input_data=input_data,
             results_dir=results_dir,
-            diag_dir=diag_dir,
+            diagnostics_dir=diagnostics_dir,
             step_name=self.step_name,
             implementation_name=self.name,
             container_full_stem=self._container_full_stem,

--- a/src/linker/implementation.py
+++ b/src/linker/implementation.py
@@ -23,13 +23,13 @@ class Implementation:
         container_engine: str,
         input_data: List[Path],
         results_dir: Path,
-        log_dir: Path,
+        diag_dir: Path,
     ) -> None:
         runner(
             container_engine=container_engine,
             input_data=input_data,
             results_dir=results_dir,
-            log_dir=log_dir,
+            diag_dir=diag_dir,
             step_name=self.step_name,
             implementation_name=self.name,
             container_full_stem=self._container_full_stem,

--- a/src/linker/pipeline.py
+++ b/src/linker/pipeline.py
@@ -32,10 +32,10 @@ class Pipeline:
         for idx, implementation in enumerate(self.implementations):
             step_number = str(idx + 1).zfill(number_of_steps_digit_length)
             previous_step_number = str(idx).zfill(number_of_steps_digit_length)
-            diag_dir = (
+            diagnostics_dir = (
                 results_dir / "diagnostics" / f"{step_number}_{implementation.step_name}"
             )
-            diag_dir.mkdir(parents=True, exist_ok=True)
+            diagnostics_dir.mkdir(parents=True, exist_ok=True)
             output_dir = (
                 results_dir
                 if idx == (number_of_steps - 1)
@@ -61,7 +61,7 @@ class Pipeline:
                 container_engine=self.config.container_engine,
                 input_data=input_data,
                 results_dir=output_dir,
-                diag_dir=diag_dir,
+                diagnostics_dir=diagnostics_dir,
             )
         if session:
             session.exit()

--- a/src/linker/pipeline.py
+++ b/src/linker/pipeline.py
@@ -25,8 +25,6 @@ class Pipeline:
         self,
         runner: Callable,
         results_dir: Path,
-        log_dir: Path,
-        #
         session: Optional["drmaa.Session"],
     ) -> None:
         number_of_steps = len(self.implementations)
@@ -34,6 +32,10 @@ class Pipeline:
         for idx, implementation in enumerate(self.implementations):
             step_number = str(idx + 1).zfill(number_of_steps_digit_length)
             previous_step_number = str(idx).zfill(number_of_steps_digit_length)
+            log_dir = (
+                results_dir / "diagnostics" / f"{step_number}_{implementation.step_name}"
+            )
+            log_dir.mkdir(parents=True, exist_ok=True)
             output_dir = (
                 results_dir
                 if idx == (number_of_steps - 1)

--- a/src/linker/pipeline.py
+++ b/src/linker/pipeline.py
@@ -32,10 +32,10 @@ class Pipeline:
         for idx, implementation in enumerate(self.implementations):
             step_number = str(idx + 1).zfill(number_of_steps_digit_length)
             previous_step_number = str(idx).zfill(number_of_steps_digit_length)
-            log_dir = (
+            diag_dir = (
                 results_dir / "diagnostics" / f"{step_number}_{implementation.step_name}"
             )
-            log_dir.mkdir(parents=True, exist_ok=True)
+            diag_dir.mkdir(parents=True, exist_ok=True)
             output_dir = (
                 results_dir
                 if idx == (number_of_steps - 1)
@@ -61,7 +61,7 @@ class Pipeline:
                 container_engine=self.config.container_engine,
                 input_data=input_data,
                 results_dir=output_dir,
-                log_dir=log_dir,
+                diag_dir=diag_dir,
             )
         if session:
             session.exit()

--- a/src/linker/runner.py
+++ b/src/linker/runner.py
@@ -55,7 +55,7 @@ def run_container(
     container_engine: str,
     input_data: List[Path],
     results_dir: Path,
-    diag_dir: Path,
+    diagnostics_dir: Path,
     step_name: str,
     implementation_name: str,
     container_full_stem: str,
@@ -67,14 +67,14 @@ def run_container(
         run_with_docker(
             input_data=input_data,
             results_dir=results_dir,
-            diag_dir=diag_dir,
+            diagnostics_dir=diagnostics_dir,
             container_path=Path(f"{container_full_stem}.tar.gz").resolve(),
         )
     elif container_engine == "singularity":
         run_with_singularity(
             input_data=input_data,
             results_dir=results_dir,
-            diag_dir=diag_dir,
+            diagnostics_dir=diagnostics_dir,
             container_path=Path(f"{container_full_stem}.sif").resolve(),
         )
     else:
@@ -93,7 +93,7 @@ def run_container(
             run_with_docker(
                 input_data=input_data,
                 results_dir=results_dir,
-                diag_dir=diag_dir,
+                diagnostics_dir=diagnostics_dir,
                 container_path=Path(f"{container_full_stem}.tar.gz").resolve(),
             )
         except Exception as e_docker:
@@ -102,7 +102,7 @@ def run_container(
                 run_with_singularity(
                     input_data=input_data,
                     results_dir=results_dir,
-                    diag_dir=diag_dir,
+                    diagnostics_dir=diagnostics_dir,
                     container_path=Path(f"{container_full_stem}.sif").resolve(),
                 )
             except Exception as e_singularity:

--- a/src/linker/runner.py
+++ b/src/linker/runner.py
@@ -16,7 +16,6 @@ from linker.utilities.slurm_utils import get_slurm_drmaa, launch_slurm_job
 def main(
     config: Config,
     results_dir: Path,
-    log_dir: Path,
 ) -> None:
     """Set up and run the pipeline"""
 
@@ -49,7 +48,7 @@ def main(
             f"provided {config.computing_environment}"
         )
 
-    pipeline.run(runner=runner, results_dir=results_dir, log_dir=log_dir, session=session)
+    pipeline.run(runner=runner, results_dir=results_dir, session=session)
 
 
 def run_container(
@@ -66,7 +65,6 @@ def run_container(
     logger.info(f"Running step '{step_name}', implementation '{implementation_name}'")
     if container_engine == "docker":
         run_with_docker(
-            implementation_name=implementation_name,
             input_data=input_data,
             results_dir=results_dir,
             log_dir=log_dir,
@@ -74,7 +72,6 @@ def run_container(
         )
     elif container_engine == "singularity":
         run_with_singularity(
-            implementation_name=implementation_name,
             input_data=input_data,
             results_dir=results_dir,
             log_dir=log_dir,
@@ -94,7 +91,6 @@ def run_container(
             )
         try:
             run_with_docker(
-                implementation_name=implementation_name,
                 input_data=input_data,
                 results_dir=results_dir,
                 log_dir=log_dir,
@@ -104,7 +100,6 @@ def run_container(
             logger.warning(f"Docker failed with error: '{e_docker}'")
             try:
                 run_with_singularity(
-                    implementation_name=implementation_name,
                     input_data=input_data,
                     results_dir=results_dir,
                     log_dir=log_dir,

--- a/src/linker/runner.py
+++ b/src/linker/runner.py
@@ -55,7 +55,7 @@ def run_container(
     container_engine: str,
     input_data: List[Path],
     results_dir: Path,
-    log_dir: Path,
+    diag_dir: Path,
     step_name: str,
     implementation_name: str,
     container_full_stem: str,
@@ -67,14 +67,14 @@ def run_container(
         run_with_docker(
             input_data=input_data,
             results_dir=results_dir,
-            log_dir=log_dir,
+            diag_dir=diag_dir,
             container_path=Path(f"{container_full_stem}.tar.gz").resolve(),
         )
     elif container_engine == "singularity":
         run_with_singularity(
             input_data=input_data,
             results_dir=results_dir,
-            log_dir=log_dir,
+            diag_dir=diag_dir,
             container_path=Path(f"{container_full_stem}.sif").resolve(),
         )
     else:
@@ -93,7 +93,7 @@ def run_container(
             run_with_docker(
                 input_data=input_data,
                 results_dir=results_dir,
-                log_dir=log_dir,
+                diag_dir=diag_dir,
                 container_path=Path(f"{container_full_stem}.tar.gz").resolve(),
             )
         except Exception as e_docker:
@@ -102,7 +102,7 @@ def run_container(
                 run_with_singularity(
                     input_data=input_data,
                     results_dir=results_dir,
-                    log_dir=log_dir,
+                    diag_dir=diag_dir,
                     container_path=Path(f"{container_full_stem}.sif").resolve(),
                 )
             except Exception as e_singularity:

--- a/src/linker/steps/dev/python_pandas/Dockerfile
+++ b/src/linker/steps/dev/python_pandas/Dockerfile
@@ -2,8 +2,10 @@
 FROM python@sha256:1c26c25390307b64e8ff73e7edf34b4fbeac59d41da41c08da28dc316a721899
 RUN mkdir -p /input_data
 RUN mkdir -p /results
+RUN mkdir -p /diagnostics
 VOLUME /results
 VOLUME /input_data
+VOLUME /diagnostics
 RUN pip install pandas==2.1.2 pyarrow
 COPY dummy_step.py .
 

--- a/src/linker/steps/pvs_like_case_study/implementations/pvs_like_python/Dockerfile
+++ b/src/linker/steps/pvs_like_case_study/implementations/pvs_like_python/Dockerfile
@@ -1,8 +1,10 @@
 FROM python:3.11-slim
 RUN mkdir -p /input_data
 RUN mkdir -p /results
+RUN mkdir -p /diagnostics
 VOLUME /results
 VOLUME /input_data
+VOLUME /diagnostics
 COPY pvs_like_case_study_sample_data.py requirements.txt ./
 RUN pip install -r requirements.txt
 CMD ["bash", "-c", "python pvs_like_case_study_sample_data.py"]

--- a/src/linker/steps/pvs_like_case_study/implementations/pvs_like_r/Dockerfile
+++ b/src/linker/steps/pvs_like_case_study/implementations/pvs_like_r/Dockerfile
@@ -1,9 +1,11 @@
 FROM continuumio/miniconda3
 RUN mkdir -p /input_data
 RUN mkdir -p /results
+RUN mkdir -p /diagnostics
 RUN mkdir -p /tmp
 VOLUME /results
 VOLUME /input_data
+VOLUME /diagnostics
 VOLUME /tmp
 COPY pvs_like_case_study_r_lock.txt pvs_like_case_study_sample_data_r.py renv.lock ./
 SHELL ["/bin/bash", "--login", "-c"]

--- a/src/linker/steps/pvs_like_case_study/implementations/pvs_like_spark_local/Dockerfile
+++ b/src/linker/steps/pvs_like_case_study/implementations/pvs_like_spark_local/Dockerfile
@@ -4,8 +4,10 @@ FROM continuumio/miniconda3 as conda-base
 # Setup I/O directories and copy the environment and Python script
 RUN mkdir -p /input_data
 RUN mkdir -p /results
+RUN mkdir -p /diagnostics
 VOLUME /results
 VOLUME /input_data
+VOLUME /diagnostics
 COPY pvs_like_case_study_sample_data_spark_local.py pvs_like_case_study_spark_local_lock_no_jupyter.txt ./
 
 # Create a new conda environment

--- a/src/linker/utilities/docker_utils.py
+++ b/src/linker/utilities/docker_utils.py
@@ -10,7 +10,6 @@ DOCKER_TIMEOUT = 360  # seconds
 
 
 def run_with_docker(
-    implementation_name: str,
     input_data: List[Path],
     results_dir: Path,
     log_dir: Path,
@@ -19,9 +18,7 @@ def run_with_docker(
     logger.info("Running container with docker")
     client = get_docker_client()
     image_id = _load_image(client, container_path)
-    container = _run_container(
-        client, image_id, implementation_name, input_data, results_dir, log_dir
-    )
+    container = _run_container(client, image_id, input_data, results_dir, log_dir)
     _clean(client, image_id, container)
 
 
@@ -52,7 +49,6 @@ def _load_image(client: DockerClient, image_path: Path) -> str:
 def _run_container(
     client: DockerClient,
     image_id: str,
-    implementation_name: str,
     input_data: List[Path],
     results_dir: Path,
     log_dir: Path,
@@ -70,7 +66,7 @@ def _run_container(
             image_id, volumes=volumes, detach=True, auto_remove=True, tty=True
         )
         logs = container.logs(stream=True, follow=True, stdout=True, stderr=True)
-        with open(log_dir / f"{implementation_name}.o", "wb") as output_file:
+        with open(log_dir / f"docker.o", "wb") as output_file:
             for log in logs:
                 output_file.write(log)
         container.wait()

--- a/src/linker/utilities/docker_utils.py
+++ b/src/linker/utilities/docker_utils.py
@@ -60,6 +60,7 @@ def _run_container(
             for dataset in input_data
         },
         str(results_dir): {"bind": "/results", "mode": "rw"},
+        str(log_dir): {"bind": "/diagnostics", "mode": "rw"},
     }
     try:
         container = client.containers.run(

--- a/src/linker/utilities/docker_utils.py
+++ b/src/linker/utilities/docker_utils.py
@@ -12,13 +12,13 @@ DOCKER_TIMEOUT = 360  # seconds
 def run_with_docker(
     input_data: List[Path],
     results_dir: Path,
-    log_dir: Path,
+    diag_dir: Path,
     container_path: Path,
 ) -> None:
     logger.info("Running container with docker")
     client = get_docker_client()
     image_id = _load_image(client, container_path)
-    container = _run_container(client, image_id, input_data, results_dir, log_dir)
+    container = _run_container(client, image_id, input_data, results_dir, diag_dir)
     _clean(client, image_id, container)
 
 
@@ -51,7 +51,7 @@ def _run_container(
     image_id: str,
     input_data: List[Path],
     results_dir: Path,
-    log_dir: Path,
+    diag_dir: Path,
 ):
     logger.info(f"Running the container from image {image_id}")
     volumes = {
@@ -60,14 +60,14 @@ def _run_container(
             for dataset in input_data
         },
         str(results_dir): {"bind": "/results", "mode": "rw"},
-        str(log_dir): {"bind": "/diagnostics", "mode": "rw"},
+        str(diag_dir): {"bind": "/diagnostics", "mode": "rw"},
     }
     try:
         container = client.containers.run(
             image_id, volumes=volumes, detach=True, auto_remove=True, tty=True
         )
         logs = container.logs(stream=True, follow=True, stdout=True, stderr=True)
-        with open(log_dir / f"docker.o", "wb") as output_file:
+        with open(diag_dir / f"docker.o", "wb") as output_file:
             for log in logs:
                 output_file.write(log)
         container.wait()

--- a/src/linker/utilities/general_utils.py
+++ b/src/linker/utilities/general_utils.py
@@ -95,10 +95,9 @@ def create_results_directory(output_dir: Optional[str], timestamp: bool) -> Path
     _ = os.umask(0o002)
     results_dir.mkdir(parents=True, exist_ok=True)
     (results_dir / "intermediate").mkdir(exist_ok=True)
-    log_dir = results_dir / "logs"
-    log_dir.mkdir(exist_ok=True)
+    (results_dir / "diagnostics").mkdir(exist_ok=True)
 
-    return results_dir, log_dir
+    return results_dir
 
 
 def load_yaml(filepath: Path) -> Dict:

--- a/src/linker/utilities/singularity_utils.py
+++ b/src/linker/utilities/singularity_utils.py
@@ -22,7 +22,7 @@ def _run_container(
     diag_dir: Path,
     container_path: Path,
 ) -> None:
-    cmd = f"singularity run --containall --no-home --bind /tmp:/tmp --bind {results_dir}:/results --bind {diag_dir}:/diagnostics"
+    cmd = f"singularity run --containall --no-home --bind /tmp:/tmp --bind {results_dir}:/results --bind {diag_dir}:/diagnostics "
     for filepath in input_data:
         cmd += f"--bind {str(filepath)}:/input_data/{str(filepath.name)} "
     cmd += f"{container_path}"

--- a/src/linker/utilities/singularity_utils.py
+++ b/src/linker/utilities/singularity_utils.py
@@ -22,7 +22,10 @@ def _run_container(
     diag_dir: Path,
     container_path: Path,
 ) -> None:
-    cmd = f"singularity run --containall --no-home --bind /tmp:/tmp --bind {results_dir}:/results --bind {diag_dir}:/diagnostics "
+    cmd = (
+        "singularity run --containall --no-home --bind /tmp:/tmp "
+        f"--bind {results_dir}:/results --bind {diag_dir}:/diagnostics "
+    )
     for filepath in input_data:
         cmd += f"--bind {str(filepath)}:/input_data/{str(filepath.name)} "
     cmd += f"{container_path}"

--- a/src/linker/utilities/singularity_utils.py
+++ b/src/linker/utilities/singularity_utils.py
@@ -6,19 +6,17 @@ from loguru import logger
 
 
 def run_with_singularity(
-    implementation_name: str,
     input_data: List[Path],
     results_dir: Path,
     log_dir: Path,
     container_path: Path,
 ) -> None:
     logger.info("Running container with singularity")
-    _run_container(implementation_name, input_data, results_dir, log_dir, container_path)
+    _run_container(input_data, results_dir, log_dir, container_path)
     _clean(results_dir, container_path)
 
 
 def _run_container(
-    implementation_name: str,
     input_data: List[Path],
     results_dir: Path,
     log_dir: Path,
@@ -28,10 +26,10 @@ def _run_container(
     for filepath in input_data:
         cmd += f"--bind {str(filepath)}:/input_data/{str(filepath.name)} "
     cmd += f"{container_path}"
-    _run_cmd(implementation_name, results_dir, log_dir, cmd)
+    _run_cmd(log_dir, cmd)
 
 
-def _run_cmd(implementation_name: str, results_dir: Path, log_dir: Path, cmd: str) -> None:
+def _run_cmd(log_dir: Path, cmd: str) -> None:
     logger.debug(f"Command: {cmd}")
     # TODO: pipe this realtime to stdout (using subprocess.Popen I think)
     process = subprocess.run(
@@ -43,7 +41,7 @@ def _run_cmd(implementation_name: str, results_dir: Path, log_dir: Path, cmd: st
     if process.returncode != 0:
         raise RuntimeError(f"Error running command '{cmd}'\n" f"Error: {process.stderr}")
 
-    with (log_dir / f"{implementation_name}.o").open(mode="a") as output_file:
+    with (log_dir / "singularity.o").open(mode="a") as output_file:
         output_file.write(f"{process.stdout}\n")
         output_file.write(process.stderr)
 

--- a/src/linker/utilities/singularity_utils.py
+++ b/src/linker/utilities/singularity_utils.py
@@ -8,31 +8,31 @@ from loguru import logger
 def run_with_singularity(
     input_data: List[Path],
     results_dir: Path,
-    diag_dir: Path,
+    diagnostics_dir: Path,
     container_path: Path,
 ) -> None:
     logger.info("Running container with singularity")
-    _run_container(input_data, results_dir, diag_dir, container_path)
+    _run_container(input_data, results_dir, diagnostics_dir, container_path)
     _clean(results_dir, container_path)
 
 
 def _run_container(
     input_data: List[Path],
     results_dir: Path,
-    diag_dir: Path,
+    diagnostics_dir: Path,
     container_path: Path,
 ) -> None:
     cmd = (
         "singularity run --containall --no-home --bind /tmp:/tmp "
-        f"--bind {results_dir}:/results --bind {diag_dir}:/diagnostics "
+        f"--bind {results_dir}:/results --bind {diagnostics_dir}:/diagnostics "
     )
     for filepath in input_data:
         cmd += f"--bind {str(filepath)}:/input_data/{str(filepath.name)} "
     cmd += f"{container_path}"
-    _run_cmd(diag_dir, cmd)
+    _run_cmd(diagnostics_dir, cmd)
 
 
-def _run_cmd(diag_dir: Path, cmd: str) -> None:
+def _run_cmd(diagnostics_dir: Path, cmd: str) -> None:
     logger.debug(f"Command: {cmd}")
     # TODO: pipe this realtime to stdout (using subprocess.Popen I think)
     process = subprocess.run(
@@ -44,7 +44,7 @@ def _run_cmd(diag_dir: Path, cmd: str) -> None:
     if process.returncode != 0:
         raise RuntimeError(f"Error running command '{cmd}'\n" f"Error: {process.stderr}")
 
-    with (diag_dir / "singularity.o").open(mode="a") as output_file:
+    with (diagnostics_dir / "singularity.o").open(mode="a") as output_file:
         output_file.write(f"{process.stdout}\n")
         output_file.write(process.stderr)
 

--- a/src/linker/utilities/singularity_utils.py
+++ b/src/linker/utilities/singularity_utils.py
@@ -22,7 +22,7 @@ def _run_container(
     log_dir: Path,
     container_path: Path,
 ) -> None:
-    cmd = f"singularity run --containall --no-home --bind /tmp:/tmp --bind {results_dir}:/results "
+    cmd = f"singularity run --containall --no-home --bind /tmp:/tmp --bind {results_dir}:/results --bind {log_dir}:/diagnostics"
     for filepath in input_data:
         cmd += f"--bind {str(filepath)}:/input_data/{str(filepath.name)} "
     cmd += f"{container_path}"

--- a/src/linker/utilities/singularity_utils.py
+++ b/src/linker/utilities/singularity_utils.py
@@ -8,28 +8,28 @@ from loguru import logger
 def run_with_singularity(
     input_data: List[Path],
     results_dir: Path,
-    log_dir: Path,
+    diag_dir: Path,
     container_path: Path,
 ) -> None:
     logger.info("Running container with singularity")
-    _run_container(input_data, results_dir, log_dir, container_path)
+    _run_container(input_data, results_dir, diag_dir, container_path)
     _clean(results_dir, container_path)
 
 
 def _run_container(
     input_data: List[Path],
     results_dir: Path,
-    log_dir: Path,
+    diag_dir: Path,
     container_path: Path,
 ) -> None:
-    cmd = f"singularity run --containall --no-home --bind /tmp:/tmp --bind {results_dir}:/results --bind {log_dir}:/diagnostics"
+    cmd = f"singularity run --containall --no-home --bind /tmp:/tmp --bind {results_dir}:/results --bind {diag_dir}:/diagnostics"
     for filepath in input_data:
         cmd += f"--bind {str(filepath)}:/input_data/{str(filepath.name)} "
     cmd += f"{container_path}"
-    _run_cmd(log_dir, cmd)
+    _run_cmd(diag_dir, cmd)
 
 
-def _run_cmd(log_dir: Path, cmd: str) -> None:
+def _run_cmd(diag_dir: Path, cmd: str) -> None:
     logger.debug(f"Command: {cmd}")
     # TODO: pipe this realtime to stdout (using subprocess.Popen I think)
     process = subprocess.run(
@@ -41,7 +41,7 @@ def _run_cmd(log_dir: Path, cmd: str) -> None:
     if process.returncode != 0:
         raise RuntimeError(f"Error running command '{cmd}'\n" f"Error: {process.stderr}")
 
-    with (log_dir / "singularity.o").open(mode="a") as output_file:
+    with (diag_dir / "singularity.o").open(mode="a") as output_file:
         output_file.write(f"{process.stdout}\n")
         output_file.write(process.stderr)
 

--- a/src/linker/utilities/slurm_utils.py
+++ b/src/linker/utilities/slurm_utils.py
@@ -36,8 +36,8 @@ def launch_slurm_job(
     jt = session.createJobTemplate()
     jt.jobName = f"{implementation_name}_{datetime.now().strftime('%Y%m%d%H%M%S')}"
     jt.joinFiles = False  # keeps stdout separate from stderr
-    jt.outputPath = f":{str(diag_dir / f'{jt.jobName}.%A.o%a')}"
-    jt.errorPath = f":{str(diag_dir / f'{jt.jobName}.%A.e%a')}"
+    jt.outputPath = f":{str(diag_dir / '%A.o%a')}"
+    jt.errorPath = f":{str(diag_dir / '%A.e%a')}"
     jt.remoteCommand = shutil.which("linker")
     jt_args = [
         "run-slurm-job",

--- a/src/linker/utilities/slurm_utils.py
+++ b/src/linker/utilities/slurm_utils.py
@@ -28,7 +28,7 @@ def launch_slurm_job(
     container_engine: str,
     input_data: List[str],
     results_dir: Path,
-    diag_dir: Path,
+    diagnostics_dir: Path,
     step_name: str,
     implementation_name: str,
     container_full_stem: str,
@@ -36,14 +36,14 @@ def launch_slurm_job(
     jt = session.createJobTemplate()
     jt.jobName = f"{implementation_name}_{datetime.now().strftime('%Y%m%d%H%M%S')}"
     jt.joinFiles = False  # keeps stdout separate from stderr
-    jt.outputPath = f":{str(diag_dir / '%A.o%a')}"
-    jt.errorPath = f":{str(diag_dir / '%A.e%a')}"
+    jt.outputPath = f":{str(diagnostics_dir / '%A.o%a')}"
+    jt.errorPath = f":{str(diagnostics_dir / '%A.e%a')}"
     jt.remoteCommand = shutil.which("linker")
     jt_args = [
         "run-slurm-job",
         container_engine,
         str(results_dir),
-        str(diag_dir),
+        str(diagnostics_dir),
         step_name,
         implementation_name,
         container_full_stem,
@@ -70,8 +70,8 @@ def launch_slurm_job(
     logger.info(
         f"Launching slurm job for step '{step_name}', implementation '{implementation_name}\n"
         f"Job submitted with jobid '{job_id}'\n"
-        f"Output log: {str(diag_dir / f'{job_id}.o*')}\n"
-        f"Error log: {str(diag_dir / f'{job_id}.e*')}"
+        f"Output log: {str(diagnostics_dir / f'{job_id}.o*')}\n"
+        f"Error log: {str(diagnostics_dir / f'{job_id}.e*')}"
     )
     job_status = session.wait(job_id, session.TIMEOUT_WAIT_FOREVER)
 

--- a/src/linker/utilities/slurm_utils.py
+++ b/src/linker/utilities/slurm_utils.py
@@ -28,7 +28,7 @@ def launch_slurm_job(
     container_engine: str,
     input_data: List[str],
     results_dir: Path,
-    log_dir: Path,
+    diag_dir: Path,
     step_name: str,
     implementation_name: str,
     container_full_stem: str,
@@ -36,14 +36,14 @@ def launch_slurm_job(
     jt = session.createJobTemplate()
     jt.jobName = f"{implementation_name}_{datetime.now().strftime('%Y%m%d%H%M%S')}"
     jt.joinFiles = False  # keeps stdout separate from stderr
-    jt.outputPath = f":{str(log_dir / f'{jt.jobName}.%A.o%a')}"
-    jt.errorPath = f":{str(log_dir / f'{jt.jobName}.%A.e%a')}"
+    jt.outputPath = f":{str(diag_dir / f'{jt.jobName}.%A.o%a')}"
+    jt.errorPath = f":{str(diag_dir / f'{jt.jobName}.%A.e%a')}"
     jt.remoteCommand = shutil.which("linker")
     jt_args = [
         "run-slurm-job",
         container_engine,
         str(results_dir),
-        str(log_dir),
+        str(diag_dir),
         step_name,
         implementation_name,
         container_full_stem,
@@ -70,8 +70,8 @@ def launch_slurm_job(
     logger.info(
         f"Launching slurm job for step '{step_name}', implementation '{implementation_name}\n"
         f"Job submitted with jobid '{job_id}'\n"
-        f"Output log: {str(log_dir / f'{job_id}.o*')}\n"
-        f"Error log: {str(log_dir / f'{job_id}.e*')}"
+        f"Output log: {str(diag_dir / f'{job_id}.o*')}\n"
+        f"Error log: {str(diag_dir / f'{job_id}.e*')}"
     )
     job_status = session.wait(job_id, session.TIMEOUT_WAIT_FOREVER)
 


### PR DESCRIPTION
## Improve logging dir structure
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: other
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4754
- *Research reference*: <!--Link to research documentation for code --> na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> Zeb requested that instead of dumping all logs into a single `logs` directory,
we create a `diagnostics` directory and then each step gets its own subdir
where logs are saved out.

While I'm at it, I've mounted the `diagnostics/` dir in the containers for those
implementations that might save out other non-log data.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
![image](https://github.com/ihmeuw/linker/assets/23350991/6d758b9e-023e-4340-ad83-cc97331476f5)


