### PR TITLE
raise when local + spark resource requests

### DIFF
--- a/src/linker/configuration.py
+++ b/src/linker/configuration.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
+from loguru import logger
+
 from linker.utilities.general_utils import load_yaml
 
 
@@ -47,10 +49,12 @@ class Config:
                 f"Container engine '{self.container_engine}' is not supported."
             )
         if self.spark and self.computing_environment == "local":
-            raise NotImplementedError(
-                "Spark resource requests are not supported in a local computing environment; "
-                "please implement a spark cluster spin-up in the actual implementation. "
-                f"Spark resources requested: {self.spark}"
+            logger.warning(
+                "Spark resource requests are not supported in a "
+                "local computing environment; these requests will be ignored. The "
+                "implementation itself is responsible for spinning up a spark cluster "
+                "inside of the relevant container.\n"
+                f"Ignored spark cluster requests: {self.spark}"
             )
 
     @staticmethod

--- a/src/linker/configuration.py
+++ b/src/linker/configuration.py
@@ -35,9 +35,6 @@ class Config:
             **self.environment[self.environment["computing_environment"]],
         }
 
-    def get_spark_resources(self) -> Dict[str, str]:
-        return {**self.environment["spark"]}
-
     #################
     # Setup Methods #
     #################
@@ -48,6 +45,12 @@ class Config:
         if not self.container_engine in ["docker", "singularity", "undefined"]:
             raise NotImplementedError(
                 f"Container engine '{self.container_engine}' is not supported."
+            )
+        if self.spark and self.computing_environment == "local":
+            raise NotImplementedError(
+                "Spark resource requests are not supported in a local computing environment; "
+                "please implement a spark cluster spin-up in the actual implementation. "
+                f"Spark resources requested: {self.spark}"
             )
 
     @staticmethod

--- a/src/linker/runner.py
+++ b/src/linker/runner.py
@@ -30,12 +30,6 @@ def main(
     if config.computing_environment == "local":
         session = None
         # TODO [MIC-4822]: launch a local spark cluster instead of relying on implementation
-        if config.spark:
-            logger.warning(
-                "Running a local pipeline with requested Spark resources is currently not supported. "
-                "The Spark resource requests will be ignored and the implementation "
-                "itself will be responsible for launching a Spark cluster locally."
-            )
         runner = run_container
     elif config.computing_environment == "slurm":
         # Set up a single drmaa.session that is persistent for the duration of the pipeline

--- a/src/linker/specifications/environment.yaml
+++ b/src/linker/specifications/environment.yaml
@@ -1,4 +1,4 @@
-computing_environment: local
+computing_environment: slurm
 container_engine: singularity  # singularity or docker; comment out completely if unknown
 slurm:
   account: proj_simscience


### PR DESCRIPTION
## Raise if a local run with spark resources requested
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc --> other
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4647
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
I forgot this bit in MIC-4647. If a user's environment.yaml specifies a 
`local` computing environment and also includes spark resource requests,
we raise (the alternative would be to warn but I'd prefer raising to make it
very clear).

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
--> tested manually

