### PR TITLE
change log level of spark warnings from warning to debug

### DIFF
--- a/src/linker/utilities/spark_utils.py
+++ b/src/linker/utilities/spark_utils.py
@@ -158,12 +158,12 @@ def find_spark_master_url(logfile: Path, attempt_sleep_time: int = 10) -> str:
                     if "Starting Spark master at" in line:
                         spark_master_url = line.split(" ")[-1:]
                 if spark_master_url == "":
-                    logger.warning(
+                    logger.debug(
                         f"Unable to find Spark master URL in logfile. Waiting {attempt_sleep_time} seconds and retrying...\n"
                         f"(attempt {read_logfile_attempt}/10)"
                     )
         except FileNotFoundError:
-            logger.warning(
+            logger.debug(
                 f"Logfile {logfile} not found. Waiting {attempt_sleep_time} seconds and retrying...\n"
                 f"(attempt {read_logfile_attempt}/10)"
             )


### PR DESCRIPTION
## Change spark wait message log level to debug
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc --> other
- *JIRA issue*: na
- *Research reference*: <!--Link to research documentation for code --> na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

