### PR TITLE
Feature/sbachmei/mic 4863 add environment defaults

### DIFF
--- a/src/linker/cli.py
+++ b/src/linker/cli.py
@@ -85,10 +85,10 @@ def run(
     results_dir = create_results_directory(output_dir, timestamp)
     logger.info(f"Results directory: {str(results_dir)}")
 
-    pipeline_specification = Path(pipeline_specification).resolve()
-    input_data = Path(input_data).resolve()
+    pipeline_specification = Path(pipeline_specification)
+    input_data = Path(input_data)
     if computing_environment:
-        computing_environment = Path(computing_environment).resolve()
+        computing_environment = Path(computing_environment)
 
     config = Config(
         pipeline_specification=pipeline_specification,

--- a/src/linker/cli.py
+++ b/src/linker/cli.py
@@ -82,16 +82,20 @@ def run(
     """Run a pipeline from the command line."""
     configure_logging_to_terminal(verbose)
     logger.info("Running pipeline")
-    pipeline_specification = Path(pipeline_specification)
-    input_data = Path(input_data)
     results_dir = create_results_directory(output_dir, timestamp)
     logger.info(f"Results directory: {str(results_dir)}")
-    # TODO [MIC-4493]: Add configuration validation
+
+    pipeline_specification = Path(pipeline_specification).resolve()
+    input_data = Path(input_data).resolve()
+    if computing_environment:
+        computing_environment = Path(computing_environment).resolve()
+
     config = Config(
         pipeline_specification=pipeline_specification,
         input_data=input_data,
         computing_environment=computing_environment,
     )
+
     main = handle_exceptions(
         func=runner.main, exceptions_logger=logger, with_debugger=with_debugger
     )
@@ -99,6 +103,7 @@ def run(
         config=config,
         results_dir=results_dir,
     )
+
     logger.info(f"Results directory: {str(results_dir)}")
     logger.info("*** FINISHED ***")
 

--- a/src/linker/configuration.py
+++ b/src/linker/configuration.py
@@ -37,11 +37,6 @@ class Config:
             if computing_environment
             else {}
         )
-        self.implementation_resources_requested = (
-            "implementation_resources" in self.environment
-        )
-        self.slurm_requested = "slurm" in self.environment
-        self.spark_requested = "spark" in self.environment
         self.environment = self._assign_default_environment(
             self.environment, DEFAULT_ENVIRONMENT_VALUES
         )

--- a/src/linker/configuration.py
+++ b/src/linker/configuration.py
@@ -50,7 +50,6 @@ class Config:
         self._validate()
 
     def get_slurm_resources(self) -> Dict[str, str]:
-        breakpoint()
         return {
             **self.environment["implementation_resources"],
             **self.environment[self.environment["computing_environment"]],
@@ -98,6 +97,7 @@ class Config:
 
     def _validate(self) -> None:
         errors = {
+            # TODO: [MIC-4723] Add config validation
             **self._validate_files(),
             **self._validate_input_data(),
         }
@@ -142,7 +142,8 @@ class Config:
                 "Computing environment is expected to be a path to an existing"
                 f" yaml file. Input was: '{computing_environment_path}'"
             )
-        return load_yaml(filepath)
+        environment = load_yaml(filepath)  # handles empty environment.yaml
+        return environment if environment else {}
 
     @staticmethod
     def _load_input_data_paths(input_data: Path) -> List[Path]:

--- a/src/linker/default_environment.yaml
+++ b/src/linker/default_environment.yaml
@@ -1,9 +1,6 @@
 # Default values used as necessary
 computing_environment: local
 container_engine: undefined
-slurm:
-  account: proj_simscience
-  partition: all.q
 implementation_resources:
   memory: 1  # GB
   cpus: 1

--- a/src/linker/default_environment.yaml
+++ b/src/linker/default_environment.yaml
@@ -1,0 +1,17 @@
+# Default values used as necessary
+computing_environment: local
+container_engine: undefined
+slurm:
+  account: proj_simscience
+  partition: all.q
+implementation_resources:
+  memory: 1  # GB
+  cpus: 1
+  time_limit: 1  # hours
+spark:
+  workers:
+    num_workers: 2  # num_workers + 1 nodes will be requested
+    cpus_per_node: 1
+    mem_per_node: 1  # GB
+    time_limit: 1  # hours
+  keep_alive: false

--- a/src/linker/pipeline.py
+++ b/src/linker/pipeline.py
@@ -62,7 +62,7 @@ class Pipeline:
             session.exit()
 
     def _get_implementations(self) -> Tuple[Implementation, ...]:
-        resources = {key: self.config.environment.get(key) for key in ["slurm", "spark"]}
+        resources = {key: self.config.environment.get(key, {}) for key in ["slurm", "spark"]}
         return tuple(
             Implementation(
                 step=step,
@@ -77,6 +77,7 @@ class Pipeline:
     def _validate(self) -> None:
         """Validates the pipeline."""
 
+        # TODO: validate that spark and slurm resources are requested if needed
         errors = {**self._validate_implementations()}
 
         if errors:

--- a/src/linker/runner.py
+++ b/src/linker/runner.py
@@ -22,9 +22,10 @@ def main(
     pipeline = Pipeline(config)
 
     # Copy config files to results
-    shutil.copy(config.pipeline_path, results_dir)
-    if config.computing_environment_path:
-        shutil.copy(config.computing_environment_path, results_dir)
+    shutil.copy(config.pipeline_specification_path, results_dir)
+    shutil.copy(config.input_data_specification_path, results_dir)
+    if config.computing_environment_specificaton_path:
+        shutil.copy(config.computing_environment_specificaton_path, results_dir)
 
     # Set up computing environment
     if config.computing_environment == "local":
@@ -42,7 +43,7 @@ def main(
         drmaa = get_slurm_drmaa()
         session = drmaa.Session()
         session.initialize()
-        resources = config.get_resources()
+        resources = config.get_slurm_resources()
         runner = partial(launch_slurm_job, session, resources)
     else:
         raise NotImplementedError(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -64,12 +64,14 @@ def test_dir(tmpdir_factory) -> str:
     with open(f"{str(tmp_path)}/environment.yaml", "w") as file:
         yaml.dump(ENV_CONFIG_DICT, file, sort_keys=False)
 
-    # input file structure
+    # input files
     input_dir1 = tmp_path.mkdir("input_data1")
     input_dir2 = tmp_path.mkdir("input_data2")
     for input_dir in [input_dir1, input_dir2]:
         for base_file in ["file1", "file2"]:
+            # good input files
             write_csv(input_dir / f"{base_file}.csv", INPUT_DATA_FORMAT_DICT["correct_cols"])
+            # bad input files
             write_csv(
                 input_dir / f"broken_{base_file}.csv",
                 INPUT_DATA_FORMAT_DICT["wrong_cols"],
@@ -95,7 +97,7 @@ def test_dir(tmpdir_factory) -> str:
             file,
             sort_keys=False,
         )
-        # input directs to files without sensible data
+    # input directs to files without sensible data
     with open(f"{tmp_path}/bad_columns_input_data.yaml", "w") as file:
         yaml.dump(
             {

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,5 @@
 import re
+from pathlib import Path
 from typing import Dict
 
 import pytest
@@ -131,9 +132,9 @@ def test_dir(tmpdir_factory) -> str:
 @pytest.fixture()
 def default_config_params(test_dir) -> Dict[str, str]:
     return {
-        "pipeline_specification": f"{test_dir}/pipeline.yaml",
-        "input_data": f"{test_dir}/input_data.yaml",
-        "computing_environment": f"{test_dir}/environment.yaml",
+        "pipeline_specification": Path(f"{test_dir}/pipeline.yaml"),
+        "input_data": Path(f"{test_dir}/input_data.yaml"),
+        "computing_environment": Path(f"{test_dir}/environment.yaml"),
     }
 
 
@@ -150,8 +151,6 @@ def default_config(default_config_params) -> Config:
 
 def check_expected_validation_exit(error, caplog, error_no, expected_msg):
     assert error.value.code == error_no
-    # We should only have one record
-    assert len(caplog.record_tuples) == 1
     # Extract error message
     msg = caplog.text.split("Validation errors found. Please see below.")[1].split(
         "Validation errors found. Please see above."

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -133,10 +133,7 @@ def test_bad_input_data(test_dir, caplog):
 FULLY_DEFINED_ENV_CONFIG = {
     "computing_environment": "foo-env",
     "container_engine": "foo-container",
-    "slurm": {
-        "account": "foo-account",
-        "partition": "foo-partition",
-    },
+    # NOTE: "slurm" does not have default values and so is not included here
     "spark": {
         "workers": {
             "cpus_per_node": "foo-cpus",
@@ -209,3 +206,19 @@ def test__assign_environment_defaults(
     # Check that values got assigned to attributes
     for key, value in expected_config.items():
         assert getattr(config, key) == value
+
+
+def test__assign_environment_defaults_bad_type(default_config_params, mocker):
+    config_params = default_config_params.copy()
+    config_params.update({"computing_environment": {"spark": "foo"}})
+    # mock out the _load_computing_environment method to return the dict directly
+    mocker.patch.object(
+        Config,
+        "_load_computing_environment",
+        return_value=config_params["computing_environment"],
+    )
+
+    with pytest.raises(
+        TypeError, match="Expected 'spark' to be of type 'dict' but found 'str'"
+    ):
+        Config(**config_params)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -147,6 +147,7 @@ FULLY_DEFINED_ENV_CONFIG = {
     },
 }
 
+
 @pytest.mark.parametrize(
     "environment_config, expected_config",
     [

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -197,7 +197,7 @@ FULLY_DEFINED_ENV_CONFIG = {
         ),
     ],
 )
-def test__assign_defaults(default_config_params, environment_config, expected_config, mocker):
+def test__assign_environment_defaults(default_config_params, environment_config, expected_config, mocker):
     config_params = default_config_params.copy()
     config_params.update({"computing_environment": environment_config})
     # mock out the _load_computing_environment method to return the dict directly

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -197,7 +197,9 @@ FULLY_DEFINED_ENV_CONFIG = {
         ),
     ],
 )
-def test__assign_environment_defaults(default_config_params, environment_config, expected_config, mocker):
+def test__assign_environment_defaults(
+    default_config_params, environment_config, expected_config, mocker
+):
     config_params = default_config_params.copy()
     config_params.update({"computing_environment": environment_config})
     # mock out the _load_computing_environment method to return the dict directly

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -161,18 +161,7 @@ FULLY_DEFINED_ENV_CONFIG = {
             },
         ),
         (
-            # check nested value: should add the missing slurm 'partition'
-            {
-                "slurm": {"account": DEFAULT_ENVIRONMENT_VALUES["slurm"]["account"]},
-            },
-            {
-                key: value
-                for key, value in DEFAULT_ENVIRONMENT_VALUES.items()
-                if key in ["computing_environment", "container_engine", "slurm"]
-            },
-        ),
-        (
-            # check a double-nested value: should add the missing 'spark: workers: num_workers' and 'spark: keep_alive: True'
+            # check nested values: should add the missing 'spark: keep_alive: True' and 'spark: workers: num_workers'
             {
                 "spark": {
                     "workers": {

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -41,9 +41,9 @@ def test_no_container(test_dir, caplog, mocker):
         "linker.implementation.Implementation._container_engine", return_value="unknown"
     )
     config_params = {
-        "pipeline_specification": f"{test_dir}/pipeline.yaml",
-        "input_data": f"{test_dir}/input_data.yaml",
-        "computing_environment": f"{test_dir}/environment.yaml",
+        "pipeline_specification": Path(f"{test_dir}/pipeline.yaml"),
+        "input_data": Path(f"{test_dir}/input_data.yaml"),
+        "computing_environment": Path(f"{test_dir}/environment.yaml"),
     }
     config = Config(**config_params)
     with pytest.raises(SystemExit) as e:
@@ -87,9 +87,9 @@ def test_implemenation_does_not_match_step(test_dir, caplog, mocker):
         side_effect=lambda x: x,
     )
     config_params = {
-        "pipeline_specification": f"{test_dir}/pipeline.yaml",
-        "input_data": f"{test_dir}/input_data.yaml",
-        "computing_environment": f"{test_dir}/environment.yaml",
+        "pipeline_specification": Path(f"{test_dir}/pipeline.yaml"),
+        "input_data": Path(f"{test_dir}/input_data.yaml"),
+        "computing_environment": Path(f"{test_dir}/environment.yaml"),
     }
     config = Config(**config_params)
     with pytest.raises(SystemExit) as e:


### PR DESCRIPTION
## Add environment defaults
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc --> implementation
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4863
- *Research reference*: <!--Link to research documentation for code --> na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> Zeb suggested that instead of dealing with defaults ad-hoc (e.g.
`spark: {keep_alive: false}` when otherwise left empty) we develop
a more standardized approach.

Sadly, that means recursion.

Basically it uses a new default_environment.yaml file which lives in the repo
and assigns like:
- If a "required" outer key (computing environment or container engine) and missing: assign
- If an optional outer key and missing: do NOT assign
- If an optional outer key but missing children: recursively assign

I also took a moment to rename some things for clarity

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
pytest written; all pass

