### PR TITLE
Remove local / distributed pyspark distinction

### DIFF
--- a/src/linker/implementation_metadata.yaml
+++ b/src/linker/implementation_metadata.yaml
@@ -24,23 +24,13 @@ step_2_python_pandas:
   step: step_2
   path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/
   name: python_pandas
-step_1_python_pyspark_distributed:
+step_1_python_pyspark:
   step: step_1
   path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/
-  name: python_pyspark_distributed
+  name: python_pyspark
   requires_spark: true
-step_2_python_pyspark_distributed:
+step_2_python_pyspark:
   step: step_2
   path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/
-  name: python_pyspark_distributed
-  requires_spark: true
-step_1_python_pyspark_local:
-  step: step_1
-  path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/
-  name: python_pyspark_distributed
-  requires_spark: true
-step_2_python_pyspark_local:
-  step: step_2
-  path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/
-  name: python_pyspark_distributed
+  name: python_pyspark
   requires_spark: true

--- a/src/linker/implementation_metadata.yaml
+++ b/src/linker/implementation_metadata.yaml
@@ -34,3 +34,13 @@ step_2_python_pyspark_distributed:
   path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/
   name: python_pyspark_distributed
   requires_spark: true
+step_1_python_pyspark_local:
+  step: step_1
+  path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/
+  name: python_pyspark_distributed
+  requires_spark: true
+step_2_python_pyspark_local:
+  step: step_2
+  path: /mnt/team/simulation_science/priv/engineering/er_ecosystem/images/
+  name: python_pyspark_distributed
+  requires_spark: true

--- a/src/linker/specifications/pipeline_2_0_0.yaml
+++ b/src/linker/specifications/pipeline_2_0_0.yaml
@@ -2,7 +2,7 @@ steps:
   step_1:
     implementation:
       name: step_1_python_pandas
-      # name: step_1_python_pyspark_distributed
+      # name: step_1_python_pyspark
       # TODO [MIC-4823 OR MIC-4824]: consider adding implementation-specific spark configurations here instead of in environment.yaml
       configuration:
         # DUMMY_CONTAINER_BROKEN: true
@@ -10,7 +10,7 @@ steps:
   step_2:
     implementation:
       # name: step_2_python_pandas
-      name: step_2_python_pyspark_distributed
+      name: step_2_python_pyspark
       configuration:
         # DUMMY_CONTAINER_BROKEN: true
         DUMMY_CONTAINER_INCREMENT: 222


### PR DESCRIPTION
## Pyspark Local Implementation
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc -->
implementation
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4830
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
I originally thought that MIC-4822 was duplicate of 4830, that is, it would be required to do the former to achieve the latter. For some reason, I forgot that I had already run "python_pyspark_distributed" locally many times, and that we don't *need* to change where/how the spark cluster is being spun up to achieve Milestone 2.2. We should consider separately when to do MIC-4822.

We just need to rename the containers, as it's a bit confusing.
### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

tested locally and on slurm, tests pass.