### PR TITLE
Pin Executor Plugin Package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ if __name__ == "__main__":
         "pyyaml",
         "pyarrow",
         "snakemake>=8.0.0",
+        #TODO MIC-4963: Resolve quoting issue and remove pin
+        "snakemake-interface-executor-plugins<9.0.0",
         "snakemake-executor-plugin-slurm",
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
         "pyyaml",
         "pyarrow",
         "snakemake>=8.0.0",
-        #TODO MIC-4963: Resolve quoting issue and remove pin
+        # TODO MIC-4963: Resolve quoting issue and remove pin
         "snakemake-interface-executor-plugins<9.0.0",
         "snakemake-executor-plugin-slurm",
     ]


### PR DESCRIPTION
## Pin Executor Plugin Package
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, implementation, refactor, revert,
                   test, release, other/misc -->
bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-XYZ
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
snakemake-interface-executor-plugins v9 broke our singularity argument commands in the snakemake CLI. Evidently at the rule level these arguments aren't formatted correctly. Unfortunately, just adding extra quotes to the arguments (or entire string) doesn't seem to work and breaks the initial parsing. I propose to pin the package version for now pending more diligent debugging (MIC-4963)

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
tested runs locally / slurm
